### PR TITLE
WIP: Add TuyaClient connection helper

### DIFF
--- a/tuyaface/__init__.py
+++ b/tuyaface/__init__.py
@@ -1,7 +1,9 @@
 import time
+import select
 import socket
 import json
 from bitstring import BitArray
+import threading
 import binascii
 from hashlib import md5
 import logging
@@ -12,7 +14,131 @@ from tuyaface.helper import *
 
 logger = logging.getLogger(__name__)
 
-   
+
+HEART_BEAT_PING_TIME = 5
+HEART_BEAT_PONG_TIME = 5
+
+class TuyaClient(threading.Thread):
+    def __init__(self, device: dict, on_status: callable):
+        super().__init__()
+        self.connection = None
+        self.device = device
+        self.force_reconnect = False
+        self.last_ping = 0
+        self.last_pong = time.time()
+        self.on_status = on_status
+        self.seq=0
+        # socketpair used to interrupt the worker thread
+        self.socketpair = socket.socketpair()
+        self.socket_lock = threading.Lock()
+        self.stop = threading.Event()
+
+    def _ping(self):
+        """ Send a ping message. """
+        self.last_ping = time.time()
+        try:
+            logger.debug("TuyaClient: PING")
+            replies = list(reply for reply in send_request(self.device, tf.HEART_BEAT, connection=self.connection, seq=self.seq))
+            self.seq += 1
+            if replies:
+                logger.debug("TuyaClient: PONG %s", replies)
+                self._reset_pong()
+        except socket.error:
+            self.force_reconnect = True
+
+    def _reset_pong(self):
+        """ Reset expired counter. """
+        self.last_pong = time.time()
+
+    def _is_connection_stale(self):
+        """ Indicates if connection has expired. """
+        if time.time() - self.last_ping > HEART_BEAT_PING_TIME:
+            self._ping()
+
+        return (time.time() - self.last_pong) > HEART_BEAT_PING_TIME + HEART_BEAT_PONG_TIME
+
+    def _connect(self):
+        self.connection = _connect(self.device)
+        self._reset_pong()
+
+    def _interrupt(self):
+        try:
+            # Write to the socket to interrupt the worker thread
+            self.socketpair[1].send(b"x")
+        except socket.error:
+            # The socketpair may already be closed during shutdown, ignore it
+            pass
+
+
+    def run(self):
+        self.connection = _connect(self.device)
+
+        while not self.stop.is_set():
+            try:
+                with self.socket_lock:
+                    if self.force_reconnect:
+                        logger.warning("TuyaClient: reconnecting")
+                        if self.connection:
+                            self.connection.close()
+                            self.connection = None
+
+                    if self.connection == None:
+                        try:
+                            logger.debug("TuyaClient: connecting")
+                            self._connect()
+                            logger.info("TuyaClient: connected")
+                        except Exception:
+                            logger.Exception()
+
+                    if self.connection:
+                        # poll the socket, as well as the socketpair to allow us to be interrupted
+                        rlist = [self.connection, self.socketpair[0]]
+                        can_read, _, _ = select.select(rlist, [], [], HEART_BEAT_PING_TIME/2)
+                        if self.connection in can_read:
+                            data = self.connection.recv(4096)
+                            for reply in _process_raw_reply(self.device, data):
+                                logger.debug("TuyaClient: Got msg %s", reply)
+                                if self.on_status:
+                                    reply = json.loads(reply["data"])
+                                    self.on_status(reply)
+
+                        if self.socketpair[0] in can_read:
+                            # Clear the socket's buffer
+                            self.socketpair[0].recv(128)
+
+                        if self._is_connection_stale():
+                             self.force_reconnect = True
+
+                if not self.connection:
+                    time.sleep(HEART_BEAT_PING_TIME/2)
+            except Exception:
+                logger.exception("TuyaClient: Unexpected exception:")
+
+    def stop(self):
+        self.stop.set()
+        self._interrupt()
+        self.join()
+
+    def status(self):
+        with self.socket_lock:
+            if self.connection == None:
+                self._connect()
+            try:
+                status(self.device, connection=self.connection, seq=self.seq)
+                self.seq += 1
+            except socket.error:
+                self.force_reconnect = True
+
+    def set_state(self, value: bool, idx: int = 1):
+        with self.socket_lock:
+            if self.connection == None:
+                self._connect()
+            try:
+                set_state(self.device, value, idx, connection=self.connection, seq=self.seq)
+                self.seq += 1
+            except socket.error:
+                self.force_reconnect = True
+
 def _generate_json_data(device_id: str, command: int, data: dict):
 
     """
@@ -142,14 +268,14 @@ def _process_raw_reply(device: dict, raw_reply: bytes):
 
                 if not isinstance(data, str):
                     data = data.decode()
-                yield data
-
+                yield {"cmd": cmd, "data": data}
             elif sbytes[20:23] == b'3.1':
 
                 logger.info('we\'ve got a 3.1 reply, code untested')                   
                 data = data[3:]  # remove version header
                 data = data[16:]  # remove (what I'm guessing, but not confirmed is) 16-bytes of MD5 hexdigest of payload
-                yield aescipher.decrypt(device['localkey'], data)
+                data_decrypt = aescipher.decrypt(device['localkey'], data)
+                yield {"cmd": cmd, "data": data_decrypt}
 
         elif device['protocol'] == '3.3':
 
@@ -158,7 +284,10 @@ def _process_raw_reply(device: dict, raw_reply: bytes):
                 data = sbytes[20:8+int.from_bytes(sbytes[14:16], byteorder='big')]
                 if cmd == tf.STATUS:
                     data = data[15:]
-                yield aescipher.decrypt(device['localkey'], data, False)
+                data_decrypt = aescipher.decrypt(device['localkey'], data, False)
+                yield {"cmd": cmd, "data": data_decrypt}
+            elif cmd in [tf.HEART_BEAT]:
+                yield {"cmd": cmd, "data": None}
     
 
 def _select_reply(replies: list):
@@ -167,40 +296,44 @@ def _select_reply(replies: list):
     returns json str
     """
 
-    filtered_replies = list(filter(lambda x: x != 'json obj data unvalid', replies))
-    if len(filtered_replies) == 0:        
-        return '{}'
-    return filtered_replies[0]
+    filtered_replies = list(filter(lambda x: x["data"] != b'json obj data unvalid' and x["data"] != 'json obj data unvalid', replies))
+    if len(filtered_replies) == 0:
+        return None
+    return filtered_replies[0]["data"]
 
 
-def _status(device: dict, cmd: int = tf.DP_QUERY, expect_reply: int = 1, recurse_cnt: int = 0):    
+
+
+def _status(device: dict, cmd: int = tf.DP_QUERY, expect_reply: int = 1, recurse_cnt: int = 0, connection=None, seq=0):
     """
     Sends current status request to the tuya device
     returns json str
     """
 
-    replies = list(reply for reply in send_request(device, cmd, None, expect_reply)) 
+    replies = list(reply for reply in send_request(device, cmd, None, expect_reply, connection=connection, seq=seq))
 
     reply = _select_reply(replies)   
     if not reply and recurse_cnt < 3:
         # some devices (ie LSC Bulbs) only offer partial status with CONTROL_NEW instead of DP_QUERY
-        reply = _status(device, tf.CONTROL_NEW, 2, recurse_cnt + 1)    
+        reply = _status(device, tf.CONTROL_NEW, 2, recurse_cnt + 1, seq=seq)
     return reply
 
 
-def status(device: dict):
+def status(device: dict, connection=None, seq=0):
     """
     Requests status of the tuya device
     returns dict
     """
 
     #TODO: validate/sanitize request
-    reply = _status(device)
-    logger.debug("reply: %s", reply) 
+    reply = _status(device, connection=connection, seq=seq)
+    logger.debug("reply: '%s'", reply)
+    if reply == None:
+        return None
     return json.loads(reply)
 
 
-def set_status(device: dict, dps: dict):
+def set_status(device: dict, dps: dict, connection=None, seq=0):
     """
     Sends status update request to the tuya device
     returns dict
@@ -208,21 +341,21 @@ def set_status(device: dict, dps: dict):
 
     #TODO: validate/sanitize request
     tmp = { str(k):v for k,v in dps.items() }
-    replies = list(reply for reply in send_request(device, tf.CONTROL, tmp, 2)) 
+    replies = list(reply for reply in send_request(device, tf.CONTROL, tmp, 2, connection=connection, seq=seq))
     
     reply = _select_reply(replies)
     logger.debug("reply: %s", reply)       
     return json.loads(reply)
 
 
-def set_state(device: dict, value: bool, idx: int = 1):
+def set_state(device: dict, value: bool, idx: int = 1, connection=None, seq=0):
     """
     Sends status update request for one dps value to the tuya device
     returns dict
     """
 
     # turn a device on / off
-    return set_status(device,{idx: value})
+    return set_status(device,{idx: value}, connection=connection, seq=seq)
 
 
 def _connect(device: dict, timeout:int = 2):
@@ -246,7 +379,7 @@ def _connect(device: dict, timeout:int = 2):
         raise e       
 
 
-def send_request(device: dict, command: int = tf.DP_QUERY, payload: dict = None, max_receive_cnt: int = 1, connection = None):
+def send_request(device: dict, command: int = tf.DP_QUERY, payload: dict = None, max_receive_cnt: int = 1, connection = None, seq=0):
     """
     Connects to the tuya device and sends the request
     returns json str or str (error)
@@ -258,14 +391,8 @@ def send_request(device: dict, command: int = tf.DP_QUERY, payload: dict = None,
     if not connection:
         connection = _connect(device)           
 
-    if command >= 0: 
-        try:   
-            #TODO: solve sequence number always 0; doesn't seem to be a problem at the moment  
-            request = _generate_payload(device, 0, command, payload)
-        except Exception as e:
-            logger.warning(e)
-            raise e
-        
+    if command >= 0:
+        request = _generate_payload(device, seq, command, payload)
         logger.debug("sending command: [%s] payload: [%s]" % (command,payload))
         try:
             connection.send(request)                  
@@ -281,4 +408,4 @@ def send_request(device: dict, command: int = tf.DP_QUERY, payload: dict = None,
         pass    
     except Exception as e: 
         raise e    
-    yield from send_request(device, -1, None, max_receive_cnt-1, connection)
+    yield from send_request(device, -1, None, max_receive_cnt-1, connection, seq)


### PR DESCRIPTION
Add simple helper class which maintains a connection to a Tuya device and receives status.
The helper class is not mandatory to use, and the changes do not intentionally break anything.

Note: Depends on #30 for correct message sequence numbering

WIP:
- Add a callback to report connect/disconnect from the Tuya device
- Needs to be cleaned up a bit
- The handling of messages received from the Tuya device can be made a bit smarter/safer when sequence number is used